### PR TITLE
CMake build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin.v2
 dist
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,49 @@
+project(odtone)
+
+cmake_minimum_required(VERSION 2.8)
+
+option(BUILD_DOCUMENTATION "Use Doxygen to create the HTML based API documentation" OFF)
+
+set(Boost_USE_MULTITHREAD ON)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+
+set(odtone_MAJOR_VERSION "0")
+set(odtone_MINOR_VERSION "5")
+set(odtone_MICRO_VERSION "0")
+set(odtone_VERSION "${odtone_MAJOR_VERSION}.${odtone_MINOR_VERSION}.${odtone_MICRO_VERSION}")
+
+set(LIB_SUFFIX "" CACHE STRING "Define suffix of directory name (32/64)" )
+set(LIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}" CACHE PATH "The subdirectory relative to the install prefix where libraries will be installed (default is /lib${LIB_SUFFIX})" FORCE)
+
+add_definitions(-DBOOST_ENABLE_ASSERT_HANDLER)
+add_subdirectory(lib/odtone)
+add_subdirectory(src/mihf)
+if(UNIX)
+  add_subdirectory(lib/external/libnl/nlwrap)
+endif()
+add_subdirectory(app/dns_usr)
+add_subdirectory(app/link_sap)
+add_subdirectory(app/link_sap_icmp)
+add_subdirectory(app/mih_usr)
+add_subdirectory(app/miis_rdf_server)
+if(UNIX)
+  add_subdirectory(app/sap_80211_linux)
+endif()
+add_subdirectory(app/sap_8023)
+if(BUILD_DOCUMENTATION)
+  add_subdirectory(doc)
+endif()
+
+# uninstall target
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake" "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake" IMMEDIATE @ONLY)
+add_custom_target(uninstall "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
+
+set(ARCHIVE_NAME ${CMAKE_PROJECT_NAME}-${odtone_VERSION})
+add_custom_target(dist
+    COMMAND mkdir -p "${CMAKE_BINARY_DIR}/${ARCHIVE_NAME}" &&
+            git log > "${CMAKE_BINARY_DIR}/${ARCHIVE_NAME}/ChangeLog" &&
+            git archive --prefix=${ARCHIVE_NAME}/ HEAD --format=tar --output="${CMAKE_BINARY_DIR}/${ARCHIVE_NAME}.tar" &&
+            tar -C "${CMAKE_BINARY_DIR}" --owner=root --group=root -r "${ARCHIVE_NAME}/ChangeLog" -f "${CMAKE_BINARY_DIR}/${ARCHIVE_NAME}.tar" &&
+            bzip2 -f9 "${CMAKE_BINARY_DIR}/${ARCHIVE_NAME}.tar" &&
+            echo "Source package created at ${CMAKE_BINARY_DIR}/${ARCHIVE_NAME}.tar.bz2.\n"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/app/dns_usr/CMakeLists.txt
+++ b/app/dns_usr/CMakeLists.txt
@@ -1,0 +1,21 @@
+project(dns_usr)
+
+find_package(Threads REQUIRED)
+
+set(app_SRC
+dns_usr.cpp
+log.cpp
+main.cpp
+query_book.cpp
+)
+
+include_directories("../../inc")
+add_executable(odtone-dns_usr ${app_SRC})
+target_link_libraries(odtone-dns_usr libodtone ${CMAKE_THREAD_LIBS_INIT})
+
+# install app
+install(FILES dns_usr.conf DESTINATION /etc/odtone/)
+install(TARGETS odtone-dns_usr EXPORT odtone-dns_usr
+                               LIBRARY DESTINATION "${LIB_INSTALL_DIR}"
+                               ARCHIVE DESTINATION "${LIB_INSTALL_DIR}"
+                               RUNTIME DESTINATION bin)

--- a/app/link_sap/CMakeLists.txt
+++ b/app/link_sap/CMakeLists.txt
@@ -1,0 +1,26 @@
+project(link_sap)
+
+find_package(Threads REQUIRED)
+
+set(app_SRC
+interface/interface.cpp
+interface/if_802_11.cpp
+link_sap.cpp
+)
+
+if(MSVC)
+	LIST(APPEND app_SRC win32/main.cpp win32/win32.cpp)
+elseif(UNIX)
+	LIST(APPEND app_SRC linux/main.cpp linux/netlink.cpp linux/rtnetlink.cpp)
+endif()
+
+include_directories("../../inc")
+add_executable(odtone-link_sap ${app_SRC})
+target_link_libraries(odtone-link_sap libodtone ${CMAKE_THREAD_LIBS_INIT})
+
+# install app
+install(FILES link_sap.conf DESTINATION /etc/odtone/)
+install(TARGETS odtone-link_sap EXPORT odtone-link_sap
+                               LIBRARY DESTINATION "${LIB_INSTALL_DIR}"
+                               ARCHIVE DESTINATION "${LIB_INSTALL_DIR}"
+                               RUNTIME DESTINATION bin)

--- a/app/link_sap_icmp/CMakeLists.txt
+++ b/app/link_sap_icmp/CMakeLists.txt
@@ -1,0 +1,19 @@
+project(link_sap_icmp)
+
+find_package(Threads REQUIRED)
+
+set(app_SRC
+main.cpp
+link_sap.cpp
+)
+
+include_directories("../../inc")
+add_executable(odtone-link_sap_icmp ${app_SRC})
+target_link_libraries(odtone-link_sap_icmp libodtone ${CMAKE_THREAD_LIBS_INIT})
+
+# install app
+install(FILES link_sap_icmp.conf DESTINATION /etc/odtone/)
+install(TARGETS odtone-link_sap_icmp EXPORT odtone-link_sap_icmp
+                               LIBRARY DESTINATION "${LIB_INSTALL_DIR}"
+                               ARCHIVE DESTINATION "${LIB_INSTALL_DIR}"
+                               RUNTIME DESTINATION bin)

--- a/app/mih_usr/CMakeLists.txt
+++ b/app/mih_usr/CMakeLists.txt
@@ -1,0 +1,18 @@
+project(mih_usr)
+
+find_package(Threads REQUIRED)
+
+set(app_SRC
+mih_usr.cpp
+)
+
+include_directories("../../inc")
+add_executable(odtone-mih_usr ${app_SRC})
+target_link_libraries(odtone-mih_usr libodtone ${CMAKE_THREAD_LIBS_INIT})
+
+# install app
+install(FILES mih_usr.conf DESTINATION /etc/odtone/)
+install(TARGETS odtone-mih_usr EXPORT odtone-mih_usr
+                               LIBRARY DESTINATION "${LIB_INSTALL_DIR}"
+                               ARCHIVE DESTINATION "${LIB_INSTALL_DIR}"
+                               RUNTIME DESTINATION bin)

--- a/app/miis_rdf_server/CMakeLists.txt
+++ b/app/miis_rdf_server/CMakeLists.txt
@@ -1,0 +1,20 @@
+project(miis_rdf_server)
+
+find_package(Threads REQUIRED)
+find_package(PkgConfig)
+pkg_check_modules(REDLAND REQUIRED redland)
+
+set(app_SRC
+miis_rdf_server.cpp
+)
+
+include_directories("../../inc" ${nlwrap_SOURCE_DIR} ${REDLAND_INCLUDE_DIRS})
+add_executable(odtone-miis_rdf_server ${app_SRC})
+target_link_libraries(odtone-miis_rdf_server libodtone ${REDLAND_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+
+# install app
+install(FILES miis_rdf_server.conf DESTINATION /etc/odtone/)
+install(TARGETS odtone-miis_rdf_server EXPORT odtone-miis_rdf_server
+                               LIBRARY DESTINATION "${LIB_INSTALL_DIR}"
+                               ARCHIVE DESTINATION "${LIB_INSTALL_DIR}"
+                               RUNTIME DESTINATION bin)

--- a/app/sap_80211_linux/CMakeLists.txt
+++ b/app/sap_80211_linux/CMakeLists.txt
@@ -1,0 +1,22 @@
+project(sap_80211_linux)
+
+find_package(Threads REQUIRED)
+find_package(PkgConfig)
+pkg_check_modules(LIBNL_ROUTE REQUIRED libnl-route-3.0)
+
+set(app_SRC
+main.cpp
+timer_task.cpp
+linux/if_80211.cpp
+)
+
+include_directories("../../inc" ${nlwrap_SOURCE_DIR} ${LIBNL_INCLUDE_DIRS})
+add_executable(odtone-sap_80211 ${app_SRC})
+target_link_libraries(odtone-sap_80211 ${CMAKE_THREAD_LIBS_INIT} ${LIBNL_ROUTE_LIBRARIES} libnlwrap libodtone)
+
+# install app
+install(FILES sap_80211.conf DESTINATION /etc/odtone/)
+install(TARGETS odtone-sap_80211 EXPORT odtone-sap_80211
+                                 LIBRARY DESTINATION "${LIB_INSTALL_DIR}"
+                                 ARCHIVE DESTINATION "${LIB_INSTALL_DIR}"
+                                 RUNTIME DESTINATION bin)

--- a/app/sap_8023/CMakeLists.txt
+++ b/app/sap_8023/CMakeLists.txt
@@ -1,0 +1,27 @@
+project(sap_8023)
+
+find_package(Threads REQUIRED)
+find_package(PkgConfig)
+pkg_check_modules(LIBNL REQUIRED libnl-3.0)
+
+set(app_SRC
+main.cpp
+timer_task.cpp
+)
+
+if(UNIX)
+	LIST(APPEND app_SRC linux/if_8023.cpp linux/ethtool.cpp)
+endif()
+
+include_directories("../../inc"
+                    ${LIBNL_INCLUDE_DIRS}
+                    ${nlwrap_SOURCE_DIR})
+add_executable(odtone-sap_8023 ${app_SRC})
+target_link_libraries(odtone-sap_8023 ${LIBNL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} libnlwrap libodtone)
+
+# install app
+install(FILES sap_8023.conf DESTINATION /etc/odtone/)
+install(TARGETS odtone-sap_8023 EXPORT odtone-sap_8023
+                               LIBRARY DESTINATION "${LIB_INSTALL_DIR}"
+                               ARCHIVE DESTINATION "${LIB_INSTALL_DIR}"
+                               RUNTIME DESTINATION bin)

--- a/cmake_uninstall.cmake
+++ b/cmake_uninstall.cmake
@@ -1,0 +1,18 @@
+file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+list(REVERSE files)
+foreach (file ${files})
+    message(STATUS "Uninstalling \"$ENV{DESTDIR}${file}\"")
+    if (EXISTS "$ENV{DESTDIR}${file}")
+        execute_process(
+            COMMAND @CMAKE_COMMAND@ -E remove "$ENV{DESTDIR}${file}"
+            OUTPUT_VARIABLE rm_out
+            RESULT_VARIABLE rm_retval
+        )
+        if(NOT ${rm_retval} EQUAL 0)
+            message(FATAL_ERROR "Problem when removing \"$ENV{DESTDIR}${file}\"")
+        endif (NOT ${rm_retval} EQUAL 0)
+    else (EXISTS "$ENV{DESTDIR}${file}")
+        message(STATUS "File \"$ENV{DESTDIR}${file}\" does not exist.")
+    endif (EXISTS "$ENV{DESTDIR}${file}")
+endforeach(file)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,0 +1,16 @@
+project(doc)
+
+find_package(Doxygen)
+if (NOT DOXYGEN_FOUND)
+  message(FATAL_ERROR 
+    "Doxygen is needed to build the documentation. Please install it correctly")
+endif()
+#-- Configure the Template Doxyfile for our specific project
+configure_file(Doxyfile.in 
+               ${PROJECT_BINARY_DIR}/Doxyfile  @ONLY IMMEDIATE)
+#-- Add a custom target to run Doxygen when ever the project is built
+add_custom_target (Docs ALL 
+                        COMMAND ${DOXYGEN_EXECUTABLE} ${PROJECT_BINARY_DIR}/Doxyfile
+                        SOURCES ${PROJECT_BINARY_DIR}/Doxyfile)
+# IF you do NOT want the documentation to be generated EVERY time you build the project
+# then leave out the 'ALL' keyword from the above command.

--- a/lib/external/libnl/nlwrap/CMakeLists.txt
+++ b/lib/external/libnl/nlwrap/CMakeLists.txt
@@ -1,0 +1,42 @@
+project(nlwrap)
+
+find_package(PkgConfig)
+pkg_check_modules(LIBNL REQUIRED libnl-3.0)
+pkg_check_modules(LIBNL_ROUTE REQUIRED libnl-route-3.0)
+pkg_check_modules(LIBNL_GEN REQUIRED libnl-genl-3.0)
+
+set(libnlwrap_MAJOR_VERSION ${odtone_MAJOR_VERSION})
+set(libnlwrap_MINOR_VERSION ${odtone_MINOR_VERSION})
+set(libnlwrap_MICRO_VERSION ${odtone_MICRO_VERSION})
+set(libnlwrap_VERSION "${libnlwrap_MAJOR_VERSION}.${libnlwrap_MINOR_VERSION}.${libnlwrap_MICRO_VERSION}")
+set(libnlwrap_SOVERSION "${libnlwrap_MAJOR_VERSION}.${libnlwrap_MINOR_VERSION}")
+
+set(libnlwrap_SRC
+nl_cb.cpp
+nl_socket.cpp
+nl_msg.cpp
+genl_msg.cpp
+genl_socket.cpp
+rtnl_socket.cpp
+rtnl_link.cpp
+rtnl_link_cache.cpp
+)
+
+include_directories("../../../../inc"
+                    ${INCLUDE_DIRECTORIES}
+                    ${LIBNL_INCLUDE_DIRS}
+                    ${LIBNL_ROUTE_INCLUDE_DIRS}
+                    ${LIBNL_GEN_INCLUDE_DIRS})
+add_library(libnlwrap SHARED ${libnlwrap_SRC})
+target_link_libraries(libnlwrap ${LIBNL_LIBRARIES} ${LIBNL_ROUTE_LIBRARIES} ${LIBNL_GEN_LIBRARIES} libodtone)
+set_target_properties(libnlwrap PROPERTIES OUTPUT_NAME "nlwrap"
+                                           VERSION ${libnlwrap_VERSION}
+                                           SOVERSION ${libnlwrap_SOVERSION}
+                                           DEFINE_SYMBOL LIBNLWRAP_EXPORTS)
+
+# install libnlwrap
+install(FILES ${libnlwrap_HEADERS} DESTINATION include/nlwrap/mih)
+install(TARGETS libnlwrap EXPORT nlwrap
+                          LIBRARY DESTINATION "${LIB_INSTALL_DIR}"
+                          ARCHIVE DESTINATION "${LIB_INSTALL_DIR}"
+                          RUNTIME DESTINATION bin)

--- a/lib/odtone/CMakeLists.txt
+++ b/lib/odtone/CMakeLists.txt
@@ -1,0 +1,73 @@
+project(libodtone)
+
+find_package(Boost 1.46 COMPONENTS system program_options thread REQUIRED)
+
+set(libodtone_MAJOR_VERSION ${odtone_MAJOR_VERSION})
+set(libodtone_MINOR_VERSION ${odtone_MINOR_VERSION})
+set(libodtone_MICRO_VERSION ${odtone_MICRO_VERSION})
+set(libodtone_VERSION "${libodtone_MAJOR_VERSION}.${libodtone_MINOR_VERSION}.${libodtone_MICRO_VERSION}")
+set(libodtone_SOVERSION "${libodtone_MAJOR_VERSION}.${libodtone_MINOR_VERSION}")
+
+set(libodtone_SRC
+strutil.cpp
+conf.cpp
+mih/types/address.cpp
+mih/config.cpp
+mih/archive.cpp
+mih/message.cpp
+net/dns/message.cpp
+net/dns/resolver.cpp
+net/dns/utils.cpp
+net/link/address_mac.cpp
+net/ip/icmp/icmp_parser.cpp
+net/ip/prefix.cpp
+debug.cpp
+sap/link.cpp
+sap/sap.cpp
+sap/user.cpp
+logger.cpp
+)
+
+if(MSVC)
+	LIST(APPEND libodtone_SRC debug_win32.cpp)
+elseif(UNIX)
+	LIST(APPEND libodtone_SRC debug_linux.cpp)
+endif()
+
+set(libodtone_base_FILE_HEADERS
+../../inc/odtone/base.hpp
+../../inc/odtone/bind_rv.hpp
+../../inc/odtone/buffer.hpp
+../../inc/odtone/cast.hpp
+../../inc/odtone/conf.hpp
+../../inc/odtone/debug.hpp
+../../inc/odtone/exception.hpp
+../../inc/odtone/list_node.hpp
+../../inc/odtone/logger.hpp
+../../inc/odtone/namespace.hpp
+../../inc/odtone/random.hpp
+../../inc/odtone/string.hpp
+../../inc/odtone/strutil.hpp
+)
+
+set(libodtone_mih_DIR_HEADERS ../../inc/odtone/mih)
+set(libodtone_sap_DIR_HEADERS ../../inc/odtone/sap)
+set(libodtone_net_DIR_HEADERS ../../inc/odtone/net)
+
+include_directories(${INCLUDE_DIRECTORIES} ${Boost_INCLUDE_DIRS} "../../inc")
+add_library(libodtone SHARED ${libodtone_SRC})
+target_link_libraries(libodtone ${Boost_LIBRARIES})
+set_target_properties(libodtone PROPERTIES OUTPUT_NAME "odtone"
+                                           VERSION ${libodtone_VERSION}
+                                           SOVERSION ${libodtone_SOVERSION}
+                                           DEFINE_SYMBOL LIBODTONE_EXPORTS)
+
+# install libodtone
+install(FILES ${libodtone_base_FILE_HEADERS} DESTINATION include/odtone)
+install(DIRECTORY ${libodtone_mih_DIR_HEADERS} DESTINATION include/odtone)
+install(DIRECTORY ${libodtone_sap_DIR_HEADERS} DESTINATION include/odtone)
+install(DIRECTORY ${libodtone_net_DIR_HEADERS} DESTINATION include/odtone)
+install(TARGETS libodtone EXPORT odtone
+                          LIBRARY DESTINATION "${LIB_INSTALL_DIR}"
+                          ARCHIVE DESTINATION "${LIB_INSTALL_DIR}"
+                          RUNTIME DESTINATION bin)

--- a/src/mihf/CMakeLists.txt
+++ b/src/mihf/CMakeLists.txt
@@ -1,0 +1,44 @@
+project(mihf)
+
+find_package(Threads REQUIRED)
+
+set(mihf_SRC
+main.cpp
+service_management.cpp
+service_access_controller.cpp
+event_service.cpp
+mihfid.cpp
+log.cpp
+command_service.cpp
+information_service.cpp
+utils.cpp
+udp_listener.cpp
+tcp_listener.cpp
+net_sap.cpp
+address_book.cpp
+link_book.cpp
+user_book.cpp
+transaction_pool.cpp
+src_transaction.cpp
+dst_transaction.cpp
+transaction.cpp
+message_in.cpp
+message_out.cpp
+transmit.cpp
+link_response_pool.cpp
+local_transaction_pool.cpp
+meta_message.cpp
+discover_service.cpp
+)
+
+include_directories("../../inc")
+add_executable(odtone-mihf ${mihf_SRC})
+target_link_libraries(odtone-mihf libodtone ${CMAKE_THREAD_LIBS_INIT})
+
+# install mihf
+install(FILES odtone.conf DESTINATION /etc/odtone/)
+install(TARGETS odtone-mihf EXPORT odtone-mihf
+                            LIBRARY DESTINATION "${LIB_INSTALL_DIR}"
+                            ARCHIVE DESTINATION "${LIB_INSTALL_DIR}"
+                            RUNTIME DESTINATION bin)
+


### PR DESCRIPTION
Introducing CMake to ODTONE.

Thumbs up points when compared to the, at least, current available Boost build system (b2/bjam) configuration:
- full dynamic linkage (bye bye static linkage of libnl & Co.)
- no need to have the full Boost source tree nor compile b2 locally, headers are more than enough to compile ODTONE
- simpler compilation steps IMO (compile flags are set by cmake rather than manually by users)
  - $ mkdir build; cd build; cmake ..; make; sudo make install
- binaries are installed in standard system directories (configuration files in /etc and such)
- dependency detection

To be done/improved:
- refine libodtone splitting in multiple library files instead of all-in-one file (improvement, easy to do)
- generate documentation (missing)
- Windows support is absent using cmake. Use bjam for now. (missing)
- dhcp_usr support (missing, easy to do)

Notes:
- bjam wasn't touched and should not conflict in any way with cmake. Users can continue using it, though they're encouraged to try cmake because it resolved lots of compilation and installation issues reported in the past
