### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: cpp
+sudo: false
+compiler:
+  - gcc
+addons:
+  apt:
+    packages:
+    - libboost-all-dev
+    - cmake
+    - libnl-3-dev
+    - libnl-route-3-dev
+    - libnl-genl-3-dev
+    - librdf0-dev
+script:
+- mkdir build
+- cd build
+- cmake ..
+# TODO: Add other targets
+- make odtone-link_sap odtone-mih_usr odtone-mihf odtone-sap_80211 odtone-sap_8023

--- a/Jamroot
+++ b/Jamroot
@@ -26,6 +26,7 @@ project odtone
 	: requirements
 		<include>inc
 		<link>static
+		<define>BOOST_ENABLE_ASSERT_HANDLER
 		<toolset>gcc:<cxxflags>-std=c++0x
 		<toolset>gcc-android:<runtime-link>static
 		<toolset>msvc:<define>BOOST_ALL_NO_LIB

--- a/app/link_sap/CMakeLists.txt
+++ b/app/link_sap/CMakeLists.txt
@@ -4,7 +4,7 @@ find_package(Threads REQUIRED)
 
 set(app_SRC
 interface/interface.cpp
-interface/if_802_11.cpp
+interface/if_802.cpp
 link_sap.cpp
 )
 


### PR DESCRIPTION
Enable CI builds with travis.

The build script uses cmake with the ubuntu boost packages. For now it only builds some of the targets.